### PR TITLE
Rename last occurances of goclimateneutral to goclimate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 # Ignore the postgres logfile
 /logfile
 
-# Ignore the local goclimateneutral database
+# Ignore the local database
 /db/goclimateneutral
 /db/goclimate
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ require 'action_cable/engine'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module GoClimateNeutral
+module GoClimate
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,14 +8,14 @@ default: &default
   adapter: postgresql
   pool: <%= ENV['RAILS_MAX_THREADS'] || 5 %>
   timeout: 500
-  database: goclimateneutral
 
 development:
   <<: *default
+  database: goclimate
 
 test:
   <<: *default
-  database: goclimateneutral_test
+  database: goclimate_test
 
 production:
   <<: *default


### PR DESCRIPTION
Moving database name configuration from default to development to clarify that production database name is configured through environment variables. Production configuration is unaffected, that is.

## Migration in our development environments

We need to do this to stay up to date (if you have any data needed for development in your dev DB, first add it to `seeds.rb` so we all can get the benefit of that):

1. Stop the Rails server, Guard and anything else connected to the DB
2. Stop Postgres: `pg_ctl -D db/goclimateneutral stop`
3. Rename the data directory: `mv db/goclimateneutral db/goclimate`
4. Start Postgres: `pg_ctl -D db/goclimate start`
5. Reset the DB: `bin/rails db:reset`