### PR TITLE
Cleanup fix for region being dropped in signup since e6f5ca1

### DIFF
--- a/app/controllers/lifestyle_footprints_controller.rb
+++ b/app/controllers/lifestyle_footprints_controller.rb
@@ -14,26 +14,21 @@ class LifestyleFootprintsController < ApplicationController
 
     render_not_found && return unless @calculator.present?
 
-    @footprint = LifestyleFootprint.new(lifestyle_calculator: @calculator)
+    @footprint = LifestyleFootprint.new(lifestyle_calculator: @calculator, country: params[:country])
   end
 
   def create
-    campaign_param = params[:campaign]
-
     @footprint = LifestyleFootprint.new(footprint_params)
     @footprint.update_from_lifestyle_calculator
     @footprint.user = current_user
     @footprint.save!
 
-    query_params = {
-      lifestyle_footprint: @footprint
-    }
-    query_params[:campaign] = campaign_param unless campaign_param.blank?
     if current_user
       redirect_to lifestyle_footprint_path(id: @footprint)
-    else
-      redirect_to new_registration_path(:user, **query_params)
+      return
     end
+
+    redirect_to new_registration_path(:user, lifestyle_footprint: @footprint, campaign: params[:campaign].presence)
   end
 
   def show
@@ -54,7 +49,7 @@ class LifestyleFootprintsController < ApplicationController
   end
 
   def footprint_params
-    params.permit(
+    params.require(:lifestyle_footprint).permit(
       :lifestyle_calculator_id, :country, :region_answer, :home_answer,
       :home_area_answer, :heating_answer, :green_electricity_answer,
       :food_answer, :shopping_answer, :car_type_answer, :flight_hours_answer

--- a/app/views/lifestyle_footprints/new.html.erb
+++ b/app/views/lifestyle_footprints/new.html.erb
@@ -152,9 +152,10 @@
           </div>
         </div>
 
-        <%= form_with url: new_lifestyle_footprint_path(@footprint, region: current_region.to_param) do |f| %>
-          <%= f.hidden_field :lifestyle_calculator_id, value: @calculator.id %>
-          <%= f.hidden_field :country, value: params[:country] %>
+        <%= form_with model: @footprint, url: new_lifestyle_footprint_path do |f| %>
+          <%= f.hidden_field :lifestyle_calculator_id %>
+          <%= f.hidden_field :country %>
+          <%= hidden_field_tag :campaign, params[:campaign] %>
 
           <% if @calculator.region_options.present? %>
             <div class="question py-8 hidden" data-target="lifestyle-footprints--calculator.question" data-category="home">
@@ -276,7 +277,6 @@
             <h2 class="heading my-4"><%=t 'views.lifestyle_footprints.questions.flight_hours' %></h2>
             <div class="flex flex-col m-lg:flex-row">
               <%= f.number_field :flight_hours_answer, min: 0, max: 2147483647, size: 7, class: 'input mb-3 m-lg:mb-0 m-lg:mr-3' %>
-              <%= f.hidden_field :campaign, value: params[:campaign] %>
               <%= f.submit t('views.lifestyle_footprints.next'), class: 'button flex-1' %>
             </div>
           </div>

--- a/spec/features/registrations_spec.rb
+++ b/spec/features/registrations_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.feature 'Registrations', type: :feature, js: true do
   scenario 'Register' do
     # Homepage
-    visit '/'
+    visit '/us'
 
     select('Sweden', from: 'country')
     click_button 'Get started'
@@ -20,6 +20,8 @@ RSpec.feature 'Registrations', type: :feature, js: true do
     click_button 'Next'
 
     # Sign up page
+    expect(page.text).to match(%r{\$[\d.]*/month}) # Verify that currency matches original region
+
     find('#continue-to-payment').click
     fill_in 'Email', with: 'test@example.com'
     fill_in 'Password', with: 'password'


### PR DESCRIPTION
Cleans up from quick fix in 851756f.

A few learnings:

- Passing a single object to a path helper that doesn't take an ID
  replaces the implicit use of params for that request (in this case
  causing the disappearance of the region param in the path)
- With routes for the same resources defined twice, form_with seems
  confused about which of them to use, even when each action is only
  present in either of the two routes. Specifying both model and url
  solves this.