### PR TITLE
Add very basic cookie consent banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -92,6 +92,28 @@
       <%= yield %>
     </div>
 
+    <% unless cookies[:cookie_consent].present? %>
+      <div id="cookie-consent-banner" class="fixed bottom-0 left-0 right-0 flex justify-between items-center p-4 t:px-8 bg-black text-white">
+        <div class="t:flex items-center space-y-4 t:space-y-0 t:space-x-4">
+          <p><%=t 'views.shared.cookie_banner.text' %></p>
+          <button id="cookie-consent-banner-consent" class="button button-sm button-inverted">
+            <%=t 'views.shared.cookie_banner.cta' %>
+          </button>
+        </div>
+      </div>
+      <script>
+        (function() {
+          var regionRecommendationElement = document.querySelector('#cookie-consent-banner');
+          var dismissElement = document.querySelector('#cookie-consent-banner-consent');
+
+          dismissElement.addEventListener('click', function(event) {
+            document.cookie = 'cookie_consent=true';
+            regionRecommendationElement.parentNode.removeChild(regionRecommendationElement);
+          });
+        })();
+      </script>
+    <% end %>
+
     <script>
       function reportLoadError(event) {
         if (typeof console !== 'undefined' && typeof console.warning !== 'undefined') {

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
     <%= render "shared/prefooter" %>
   <% end %>
 
-  <section class="bg-primary text-white text-sm p-4 py-6 t:px-8 t:py-12 space-y-4">
+  <section class="bg-primary text-white text-sm p-4 pt-6 pb-36 t:px-8 t:pt-12 t:pb-20 space-y-4">
     <div class="flex flex-row flex-wrap -m-4">
       <div class="w-full d:w-2/5 flex-grow p-4 space-y-4">
         <div>
@@ -91,7 +91,7 @@
     </div>
 
     
-    <div class="text-right space-y-2">
+    <div class="text-center space-y-2">
       <div>
         <div class="dropdown">
           <input type="checkbox" id="region-picker" class="dropdown-toggler">

--- a/config/locales/views/shared.en.yml
+++ b/config/locales/views/shared.en.yml
@@ -38,3 +38,6 @@ en:
           title: 100% Transparency
           description: We want you to feel safe with how your money makes an impact. See our outgoings, making sure that you know where every cent is used.
           cta: See our numbers
+      cookie_banner:
+        text: Cookies help us deliver our services. By using our services, you agree to our use of cookies.
+        cta: I consent

--- a/config/locales/views/shared.sv.yml
+++ b/config/locales/views/shared.sv.yml
@@ -38,3 +38,6 @@ sv:
           title: 100 % transparens
           description: Vi vill att du ska känna dig helt trygg med hur dina pengar gör klimatnytta. Vi redovisar löpande alla våra utgifter här på siten, för att du ska veta exakt hur pengarna används.
           cta: Se alla våra siffror
+      cookie_banner:
+        text: Kakor hjälper oss att leverera våra tjänster. Genom att använda våra tjänster godkänner du vår användning av kakor.
+        cta: Jag godkänner


### PR DESCRIPTION
- Added a very basic cookie consent banner
- Small design changes in footer so the privacy policy link is not blocked by the intercom bubble

Next step would be to have more information on what cookies we actually use and to deny them.