### PR TITLE
Email validation when signing up

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :subscription_months, class_name: 'Subscriptions::SubscriptionMonth'
   belongs_to :referred_from, class_name: 'Subscriptions::ReferralCode', optional: true
 
+  validates :email, format: { with: /\A[a-z0-9+\-_.]+@[a-z\d\-.]+\.[a-z]{2,6}\z/i }, on: :create
   validates :user_name, format: { without: /.+@.+\..+/ }, allow_blank: true
 
   attribute :region, :region

--- a/app/views/devise/registrations/_sign_up_form.erb
+++ b/app/views/devise/registrations/_sign_up_form.erb
@@ -143,13 +143,15 @@
           </p>
         </div>
       </div>
-        <div class="hidden" data-target="registrations--membership-choice.noSubscriptionInfo" data-inactive-class="hidden">
-          <div class="py-6 space-y-1">
-            <p class="heading-lg text-center">
-              <span class="hidden" data-target="registrations--membership-choice.noSubscriptionInfo" data-active-class="inline" data-inactive-class="hidden"><%= t 'views.registrations.price_free' %></span>
-            </p>
-          </div>
+      <div class="hidden" data-target="registrations--membership-choice.noSubscriptionInfo" data-inactive-class="hidden">
+        <div class="py-6 space-y-1">
+          <p class="heading-lg text-center">
+            <span class="hidden" data-target="registrations--membership-choice.noSubscriptionInfo" data-active-class="inline" data-inactive-class="hidden"><%= t 'views.registrations.price_free' %></span>
+          </p>
         </div>
+      </div>
+
+      <p class="text-orange-shade-1 pb-3" data-target="registrations--form.errorMessage"></p>
 
       <button class="button button-cta w-full"
         data-target="registrations--membership-choice.subscriptionInfo"
@@ -173,7 +175,6 @@
       <p class="mt-3 text-sm text-center text-gray-shade-2">
         <%= t('views.registrations.accept_policies').gsub("<a>", "<a href='#{privacy_policy_path}' class='link' target='_blank'>").html_safe %>
       </p>
-      <p class="text-orange-shade-1 ml-4" data-target="registrations--form.errorMessage"></p>
       <div class="mt-3 flex justify-between">
         <div><label for="step-one-done" class="link-ui text-sm"><- <%= t 'views.registrations.back' %></label></div>
         <span class="text-sm"><%= t 'views.registrations.step' %> 2/2</span>

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,5 +54,7 @@ module GoClimate
     end
 
     config.exceptions_app = routes
+
+    config.active_model.i18n_customize_full_message = true
   end
 end

--- a/config/locales/activerecord.de.yml
+++ b/config/locales/activerecord.de.yml
@@ -10,9 +10,12 @@ de:
             password:
               too_short: Das Passwort ist zu kurz. Es sollte mind. 6 Zeichen enthalten!
               blank: Ups, offenbar fehlt das Passwort!
+              format: '%{message}'
             email:
               taken: Diese E-Mail Adresse existiert bereits, versuchen Sie es mit einer anderen!
               blank: Dieses Feld scheint leer zu sein!
               invalid: Scheinbar ist ein Fehler aufgetreten, versuchen Sie es noch einmal!
+              format: '%{message}'
             privacy_policy:
               accepted: Sie müssen die Datenschutzerklärung akzeptieren
+              format: '%{message}'

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -10,9 +10,12 @@ en:
               password:
                 too_short: The password is too short, please try at least 6 characters!
                 blank: Wops, the password looks like it´s empty!
+                format: '%{message}'
               email:
                 taken: The email address already exists, try another one!
-                blank: can't be blank
+                blank: The email address can't be blank
                 invalid: The email looks incorrect, try again!
+                format: '%{message}'
               privacy_policy:
                 accepted: You need to accept the pricacy policy
+                format: '%{message}'

--- a/config/locales/activerecord.sv.yml
+++ b/config/locales/activerecord.sv.yml
@@ -10,9 +10,12 @@ sv:
             password:
               too_short: Lösenordet är för kort, minst 6 tecken!
               blank: Oj, lösenordet ser tomt ut!
+              format: '%{message}'
             email:
               taken: Användaren finns redan registrerad hos oss, prova med en annan e-postadress!
-              blank: måste anges
-              invalid: E-postadressen ser konstig ut, prova igen!
+              blank: E-postadress måste anges
+              invalid: E-postadressen ser felaktig ut, prova igen!
+              format: '%{message}'
             privacy_policy:
               accepted: Du behöver acceptera integritetspolocyn för att gå vidare
+              format: '%{message}'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -69,6 +69,26 @@ RSpec.describe User do
     end
   end
 
+  describe '#email' do
+    context 'with a valid email' do
+      subject { build(:user, email: 'test@example.com') }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'with a completely invalid email' do
+      subject { build(:user, email: 'test.test') }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context 'with an invalid email according to our standard' do
+      subject { build(:user, email: 'test@test') }
+
+      it { is_expected.to be_invalid }
+    end
+  end
+
   describe '#user_name' do
     context 'with a user_name with an @ sign' do
       subject { build(:user, user_name: 'Jod@') }


### PR DESCRIPTION
I have tested the regex as follows:
![Screenshot 2021-09-01 at 14 11 37](https://user-images.githubusercontent.com/8473077/131669061-223b8832-517c-4c6c-bfb6-9c6f675058a9.png)

The reason for updating the formatting of the auto error messages from Activerecord is that it by default show the field that's causing the error (see image below). I removed the "Email" prefix

![Screenshot 2021-09-01 at 12 43 26](https://user-images.githubusercontent.com/8473077/131666252-81a6f41b-b68f-49cd-a947-09a9548abfbf.png)

