### PR TITLE
Cleanup ghg formatting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development, :test do
   gem 'capybara', '~> 3.30'
   gem 'dotenv-rails'
   gem 'factory_bot_rails'
+  gem 'pry-byebug' # Drop `binding.pry` anywhere you want to start debugging
   gem 'rb-readline'
   gem 'rspec_junit_formatter'
   gem 'rspec-rails', '~> 4.0'
@@ -85,7 +86,6 @@ group :development do
   gem 'guard-rspec', require: false
   gem 'guard-rubocop', require: false
   gem 'i18n-tasks', require: false
-  gem 'pry-byebug' # Drop `binding.pry` anywhere you want to start debugging
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Guardfile
+++ b/Guardfile
@@ -61,7 +61,7 @@ group :javascript do
   end
 end
 
-guard :brakeman, run_on_start: false do
+guard :brakeman, quiet: true do
   watch(%r{^app/.+\.(erb|haml|rhtml|rb)$})
   watch(%r{^config/.+\.rb$})
   watch('Gemfile')

--- a/app/controllers/flight_footprints_controller.rb
+++ b/app/controllers/flight_footprints_controller.rb
@@ -6,7 +6,7 @@ class FlightFootprintsController < ApplicationController
 
   def create
     render json: {
-      footprint: footprint.footprint.to_s(precision: :auto),
+      footprint: footprint.footprint.to_s(unit: :tonnes),
       price: footprint.footprint.consumer_price(current_region.currency).to_s,
       offset_path: new_flight_offset_path(offset_params: offset_params, num_persons: params[:num_persons])
     }

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -127,7 +127,7 @@ module Users
 
     def render_price_json
       render json: {
-        subscription: @plan.footprint.to_s(precision: :auto),
+        subscription: @plan.footprint.to_s(unit: :tonnes),
         price: @plan.price.to_s(precision: :auto)
       }
     end

--- a/app/models/greenhouse_gases.rb
+++ b/app/models/greenhouse_gases.rb
@@ -88,17 +88,28 @@ class GreenhouseGases
     GreenhouseGases.new(co2e - other.co2e)
   end
 
-  def to_s(options = {})
-    if options[:precision] == :auto
-      rounded_tonnes = (BigDecimal(co2e) / 1000).round(co2e < 100 ? 2 : 1)
+  def to_s(unit: :kgs, precision: nil)
+    case unit
+    when :kgs
+      I18n.translate(
+        'models.greenhouse_gases.kg',
+        count: co2e,
+        formatted_count: ActiveSupport::NumberHelper.number_to_delimited(co2e)
+      )
+    when :tonnes
+      precision ||= co2e < 100 ? 2 : 1
+      rounded_tonnes = tonnes.round(precision)
 
-      return I18n.translate('models.greenhouse_gases.tonnes', count: rounded_tonnes)
-    end
-
-    if co2e % 1000 == 0
-      I18n.translate('models.greenhouse_gases.tonnes', count: co2e / 1000)
-    else
-      I18n.translate('models.greenhouse_gases.kg', count: co2e)
+      I18n.translate(
+        'models.greenhouse_gases.tonnes',
+        count: rounded_tonnes,
+        formatted_count: ActiveSupport::NumberHelper.number_to_rounded(
+          rounded_tonnes,
+          # Default delimiter for number_to_rounded is no delimiter, so we need to pass the locale delimiter explicitly
+          delimiter: I18n.translate(:'number.format.delimiter'),
+          precision: precision
+        )
+      )
     end
   end
 

--- a/app/views/devise/registrations/_chart_world_comparison.html.erb
+++ b/app/views/devise/registrations/_chart_world_comparison.html.erb
@@ -25,7 +25,7 @@
 </div>
 <p>
   <% footprint_text_options = {
-      footprint: @footprint.total.to_s(precision: :auto),
+      footprint: @footprint.total.to_s(unit: :tonnes),
       relative:
         if @footprint.total > @country_average.co2e
           "#{((@footprint.total.co2e.to_f / @country_average.co2e.co2e - 1) * 100).ceil} % #{t 'views.registrations.higher'}"

--- a/app/views/devise/registrations/new_campaign.html.erb
+++ b/app/views/devise/registrations/new_campaign.html.erb
@@ -95,7 +95,7 @@
 
           <div class="flex justify-between">
             <span class="font-semibold"><%= t 'views.registrations.know_your_footprint.sign_up.free_account.your_footprint' %></span>
-            <span class="text-right"><%= @plan.footprint.to_s(precision: :auto) %>/<%= t 'years.one' %></span>
+            <span class="text-right"><%= @plan.footprint.to_s(unit: :tonnes) %>/<%= t 'years.one' %></span>
           </div>
 
           <div class="h-px w-full bg-gray-tint-2"></div>
@@ -139,7 +139,7 @@
 
           <div class="flex justify-between">
             <span class="font-semibold"><%= t 'views.registrations.your_subscription' %></span>
-            <span class="text-right"><span data-target="registrations--price.subscription"><%= @plan.footprint.to_s(precision: :auto) %></span>/<%= t 'years.one' %></span>
+            <span class="text-right"><span data-target="registrations--price.subscription"><%= @plan.footprint.to_s(unit: :tonnes) %></span>/<%= t 'years.one' %></span>
           </div>
 
           <div class="h-px w-full bg-gray-tint-2"></div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -81,7 +81,7 @@
 
           <div class="text-sm mt-3">
             <%=l project.date_bought.to_date %> &bull;
-            <%= project.co2e.to_s(precision: 0) %> &bull;
+            <%= project.co2e.to_s(unit: :tonnes, precision: 0) %> &bull;
             <%=t "models.project.offset_type.#{project.offset_type}" %> &bull;
             <% if project.certificate_url.present? %>
               <%= link_to t('views.projects.index.invoice'), project.invoice_url, target: '_blank' %> &bull;

--- a/app/views/users/subscriptions/show.html.erb
+++ b/app/views/users/subscriptions/show.html.erb
@@ -36,7 +36,7 @@
                     <% else %>
                       <%= plan.price.to_s(precision: :auto) %>
                     <% end %>
-                    (<%= plan.footprint.to_s(precision: :auto) %>/<%= t 'years.one' %>)
+                    (<%= plan.footprint.to_s(unit: :tonnes) %>/<%= t 'years.one' %>)
                   </option>
                 <% end %>
               </select>

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -8,11 +8,11 @@ de:
         eur: '€'
     greenhouse_gases:
       tonnes:
-        one: '%{count} Tonnen CO2e'
-        other: '%{count} Tonnen CO2e'
+        one: '%{formatted_count} Tonnen CO2e'
+        other: '%{formatted_count} Tonnen CO2e'
       kg:
-        one: '%{count} kg CO2e'
-        other: '%{count} kg CO2e'
+        one: '%{formatted_count} kg CO2e'
+        other: '%{formatted_count} kg CO2e'
     project:
       offset_type:
         'GS': Gold Standard zertifiziert

--- a/config/locales/models.en.yml
+++ b/config/locales/models.en.yml
@@ -28,11 +28,11 @@ en:
         usd: 'DEFAULT'
     greenhouse_gases:
       tonnes:
-        one: '%{count} tonne CO2e'
-        other: '%{count} tonnes CO2e'
+        one: '%{formatted_count} tonne CO2e'
+        other: '%{formatted_count} tonnes CO2e'
       kg:
-        one: '%{count} kg CO2e'
-        other: '%{count} kg CO2e'
+        one: '%{formatted_count} kg CO2e'
+        other: '%{formatted_count} kg CO2e'
     project:
       offset_type:
         'GS': Gold Standard certified

--- a/config/locales/models.eo.yml
+++ b/config/locales/models.eo.yml
@@ -28,11 +28,11 @@ eo:
         usd: 'crwdns12680:0crwdne12680:0'
     greenhouse_gases:
       tonnes:
-        one: 'crwdns12686:1%{count}crwdne12686:1'
-        other: 'crwdns12686:5%{count}crwdne12686:5'
+        one: 'crwdns12686:1%{formatted_count}crwdne12686:1'
+        other: 'crwdns12686:5%{formatted_count}crwdne12686:5'
       kg:
-        one: 'crwdns12688:1%{count}crwdne12688:1'
-        other: 'crwdns12688:5%{count}crwdne12688:5'
+        one: 'crwdns12688:1%{formatted_count}crwdne12688:1'
+        other: 'crwdns12688:5%{formatted_count}crwdne12688:5'
     project:
       offset_type:
         'GS': crwdns12690:0crwdne12690:0

--- a/config/locales/models.sv.yml
+++ b/config/locales/models.sv.yml
@@ -13,11 +13,11 @@ sv:
         sek: ' kr'
     greenhouse_gases:
       tonnes:
-        one: '%{count} ton koldioxid'
-        other: '%{count} ton koldioxid'
+        one: '%{formatted_count} ton koldioxid'
+        other: '%{formatted_count} ton koldioxid'
       kg:
-        one: '%{count} kg koldioxid'
-        other: '%{count} kg koldioxid'
+        one: '%{formatted_count} kg koldioxid'
+        other: '%{formatted_count} kg koldioxid'
     project:
       offset_type:
         'GS': Gold Standard-certifierat

--- a/spec/models/greenhouse_gases_spec.rb
+++ b/spec/models/greenhouse_gases_spec.rb
@@ -94,20 +94,42 @@ RSpec.describe GreenhouseGases do
   end
 
   describe '#to_s' do
-    it 'uses tonnes when evenly divisible by tonnes' do
-      expect(described_class.new(1000).to_s).to eq('1 tonne CO2e')
-    end
-
-    it 'uses kgs when not evenly divisible by tonnes' do
+    it 'formats in kgs by default ' do
       expect(described_class.new(768).to_s).to eq('768 kg CO2e')
     end
 
-    it 'rounds to nearest 0.1 tonnes with option precision: :auto' do
-      expect(described_class.new(768).to_s(precision: :auto)).to eq('0.8 tonnes CO2e')
+    it 'uses delimiters for large numbers' do
+      expect(described_class.new(1_000).to_s).to eq('1,000 kg CO2e')
     end
 
-    it 'rounds to nearest 0.01 tonnes with option precision: :auto and values under 0.1 tonnes' do
-      expect(described_class.new(68).to_s(precision: :auto)).to eq('0.07 tonnes CO2e')
+    it 'rounds to nearest 0.1 tonnes with option unit: :tonnes' do
+      expect(described_class.new(768).to_s(unit: :tonnes)).to eq('0.8 tonnes CO2e')
+    end
+
+    it 'rounds to nearest 0.01 tonnes with option unit: :tonnes and values under 0.1 tonnes' do
+      expect(described_class.new(68).to_s(unit: :tonnes)).to eq('0.07 tonnes CO2e')
+    end
+
+    it 'allows setting precision for tonnes' do
+      expect(described_class.new(50_100).to_s(unit: :tonnes, precision: 0)).to eq('50 tonnes CO2e')
+    end
+
+    it 'delimits large numbers in tonnes' do
+      expect(described_class.new(500_000_100).to_s(unit: :tonnes)).to eq('500,000.1 tonnes CO2e')
+    end
+
+    context 'with a locale with different formatting' do
+      around do |example|
+        I18n.with_locale(:sv, &example)
+      end
+
+      it 'uses delimiter for kgs' do
+        expect(described_class.new(1_000).to_s).to eq('1 000 kg koldioxid')
+      end
+
+      it 'uses delimiter and separator for tonnes' do
+        expect(described_class.new(1_000_100).to_s(unit: :tonnes)).to eq('1 000,1 ton koldioxid')
+      end
     end
   end
 end


### PR DESCRIPTION
Changes:

- Doesn't switch automatically between kgs and tonnes. Do that explicitly instead.
- Now uses delimiters and separators from current locale.

Specifically to adress the request to make admin dashboard more legible:

<img width="343" alt="Screen Shot 2021-09-07 at 15 19 57" src="https://user-images.githubusercontent.com/90949/132351741-66e46644-e5fa-4c7e-a76e-f1c739370a70.png">
