### PR TITLE
Tweak cancellation buttons

### DIFF
--- a/app/views/users/subscriptions/show.html.erb
+++ b/app/views/users/subscriptions/show.html.erb
@@ -105,7 +105,7 @@
       <div class="callout max-w-xl mx-auto">
         <h2 class="heading mb-3"><%= t 'views.subscriptions.cancel.heading' %></h2>
         <div data-controller="modal">
-          <button type="button" id="start_cancellation" class="button button-danger w-full" data-target="modal.trigger" data-action="modal#open">
+          <button type="button" id="start_cancellation" class="button w-full" data-target="modal.trigger" data-action="modal#open">
             <%= t('views.subscriptions.cancel.action') %>
           </button>
 
@@ -139,8 +139,8 @@
                   <% end %>
                 </div>
                 <div class="modal-actions">
-                  <button type="button" class="button button-cta" data-action="modal#close"><%= t('views.subscriptions.cancel.abort') %></button>
-                  <%= button_tag t('views.subscriptions.cancel.action'), id: 'confirm_cancellation', class: 'button', type: 'submit' %>
+                  <button type="button" class="button" data-action="modal#close"><%= t('views.subscriptions.cancel.abort') %></button>
+                  <%= button_tag t('views.subscriptions.cancel.action'), id: 'confirm_cancellation', class: 'button button-danger', type: 'submit' %>
                 </div>
               <% end %>
             </div>


### PR DESCRIPTION
I think the current situation is a little bit confusing. This change aims to:

- Draw less attention to cancelling your subscription.
- Clarify that the danger is actually happening when clicking cancel in
  the modal.

## Before
<img width="604" alt="Screen Shot 2021-09-07 at 15 38 40" src="https://user-images.githubusercontent.com/90949/132355150-97cdceb6-e6ed-4bcc-9719-9768873ae672.png">
<img width="698" alt="Screen Shot 2021-09-07 at 15 39 00" src="https://user-images.githubusercontent.com/90949/132354605-eb98b355-9829-432d-9b50-05590d64aeda.png">

## After
<img width="604" alt="Screen Shot 2021-09-07 at 15 38 40" src="https://user-images.githubusercontent.com/90949/132354630-2f487c1c-1693-4b1c-8da1-33805f69cbee.png">
<img width="691" alt="Screen Shot 2021-09-07 at 15 38 44" src="https://user-images.githubusercontent.com/90949/132354637-58456c53-e01e-4823-bf27-0d70b33b026d.png">
