### PR TITLE
Adding gem awesome print where it pretty prints ruby objects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,9 @@ gem 'wkhtmltopdf-binary', '0.12.4' # Later versions don't work on CircleCI
 
 gem 'meta-tags'
 
+# Pretty prints ruby objects
+gem 'awesome_print'
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'capybara', '~> 3.30'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    awesome_print (1.9.2)
     barnes (0.0.9)
       multi_json (~> 1)
       statsd-ruby (~> 1.1)
@@ -360,6 +361,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  awesome_print
   barnes
   bootsnap (~> 1.3)
   brakeman


### PR DESCRIPTION
I lovveeee this gem.  💟 
Let's please add this?

Eg:
`irb(main):002:0>  FlightOffset.last`

  `FlightOffset Load (0.4ms)  SELECT "flight_offsets".* FROM "flight_offsets" ORDER BY "flight_offsets"."id" DESC LIMIT $1  [["LIMIT", 1]]
=> #<FlightOffset id: 11, created_at: "2021-09-09 14:13:53", updated_at: "2021-09-09 14:13:56", key: "dff8dfdef8158c356cdc4d5fa5e67103ade16749", co2e: 300 kg CO2e, email: "nandita__111@goclimate.com", stripe_charge_id: nil, price: 180, currency: #<struct Currency iso_code=:eur, rounding_precision=-1, small_amount_price_step=50, large_amount_price_step=100>, payment_intent_id: "pi_3JXo0jHwuhGySQCd0uttRGTV", paid_at: "2021-09-09 14:13:56", user_id: nil>`

**with gem**


<img width="569" alt="Screenshot 2021-09-09 at 8 12 32 PM" src="https://user-images.githubusercontent.com/89521136/132707090-1954a849-9d15-4d44-a3de-fbc42f3d5b9e.png">
