### PR TITLE
Business newsletter subscriber3

### DIFF
--- a/app/assets/main/controllers/newsletter_subscription_controller.js
+++ b/app/assets/main/controllers/newsletter_subscription_controller.js
@@ -22,13 +22,22 @@ export default class NewsletterSubscriptionController extends Controller {
         }
       })
       .catch((error) => {
-        if (error.status === 400) {
-          this.setErrorMessage('Please enter a valid email address.');
-        } else {
-          window.Sentry.captureException(error); // These errors are unexpected, so report them.
-          this.setErrorMessage('An unexpected error occurred. Please start over and try again. If the issue remains, please contact us at hello@goclimate.com.');
-        }
-        this.enableIdleState();
+        error.json()
+          .then((data) => {
+            if (data.status === 400 && data.errors.email.includes('duplicate')) {
+              this.clearEmailField();
+              this.enableSuccessState();
+              return;
+            }
+
+            if (data.status === 400) {
+              this.setErrorMessage('Please enter a valid email address.');
+            } else {
+              window.Sentry.captureException(data); // These errors are unexpected, so report them.
+              this.setErrorMessage('An unexpected error occurred. Please start over and try again. If the issue remains, please contact us at hello@goclimate.com.');
+            }
+            this.enableIdleState();
+          });
       });
   }
 
@@ -38,7 +47,6 @@ export default class NewsletterSubscriptionController extends Controller {
 
   handleSuccess() {
     this.enableSuccessState();
-    setTimeout(() => { this.enableIdleState(); }, 2000);
   }
 
   setErrorMessage(errorMessage) {
@@ -52,16 +60,19 @@ export default class NewsletterSubscriptionController extends Controller {
   }
 
   enableSuccessState() {
-    swapToActiveClassList(this.successIndicatorTarget);
+    swapToActiveClassList(this.successMessageTarget);
+    swapToInactiveClassList(this.formWrapperTarget);
     swapToInactiveClassList(this.idleIndicatorTarget);
     swapToInactiveClassList(this.loadingIndicatorTarget);
   }
 
   enableIdleState() {
     swapToActiveClassList(this.idleIndicatorTarget);
+    swapToInactiveClassList(this.successMessageTarget);
+    swapToActiveClassList(this.formWrapperTarget);
     swapToInactiveClassList(this.loadingIndicatorTarget);
     swapToInactiveClassList(this.successIndicatorTarget);
   }
 }
 
-NewsletterSubscriptionController.targets = ['emailField', 'idleIndicator', 'loadingIndicator', 'successIndicator', 'errorMessage'];
+NewsletterSubscriptionController.targets = ['emailField', 'idleIndicator', 'loadingIndicator', 'successIndicator', 'errorMessage', 'formWrapper', 'successMessage'];

--- a/app/assets/shared/components/dropdown.css
+++ b/app/assets/shared/components/dropdown.css
@@ -13,7 +13,7 @@
     rounded
     text-primary text-left bg-white
     shadow
-    z-10;
+    z-40;
 
     @nest .dropdown-toggler:checked ~ & {
       @apply block;

--- a/app/controllers/newsletter_subscribers_controller.rb
+++ b/app/controllers/newsletter_subscribers_controller.rb
@@ -16,6 +16,12 @@ class NewsletterSubscribersController < ApplicationController
       return
     end
 
+    if params[:newsletter_type] == NewsletterSubscriber::BUSINESS_TYPE
+      NewsletterMailer.business_newsletter_signup_email(params[:newsletter_email]).deliver_now
+    else
+      NewsletterMailer.newsletter_signup_email(params[:newsletter_email]).deliver_now
+    end
+
     head :ok
   end
 end

--- a/app/controllers/newsletter_subscribers_controller.rb
+++ b/app/controllers/newsletter_subscribers_controller.rb
@@ -3,20 +3,19 @@
 class NewsletterSubscribersController < ApplicationController
   def create
     params.require(:newsletter_email)
-    params.permit(:logged_in_user_id, :region)
+    params.permit(:newsletter_email, :user_id, :region, :newsletter_type)
     subscriber = NewsletterSubscriber.new(
       email: params[:newsletter_email],
-      logged_in_user_id: params[:logged_in_user_id],
-      region: params[:region]
+      user_id: params[:user_id],
+      region: params[:region],
+      newsletter_type: params[:newsletter_type]
     )
 
-    if subscriber.save
-      head :ok
-    else
-      render(
-        status: :bad_request,
-        json: { error: { message: 'email' } }
-      )
+    unless subscriber.save
+      render(status: :bad_request, json: { status: 400, errors: subscriber.errors })
+      return
     end
+
+    head :ok
   end
 end

--- a/app/mailers/newsletter_mailer.rb
+++ b/app/mailers/newsletter_mailer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class NewsletterMailer < ApplicationMailer
+  def newsletter_signup_email(email)
+    mail(
+      from: "#{I18n.t('mailers.welcome.from', name: 'Tove')} <tove@goclimate.com>",
+      reply_to: "#{I18n.t('mailers.welcome.from', name: 'Tove')} <tove@goclimate.com>",
+      to: email,
+      subject: I18n.t('mailers.newsletter.sign_up.subject'),
+      asm: { group_id: SENDGRID_ASM_GROUP_IDS[:newsletter] }
+    )
+  end
+
+  def business_newsletter_signup_email(email)
+    mail(
+      to: email,
+      from: "#{I18n.t('mailers.welcome.from', name: 'Tove')} <tove@goclimate.com>",
+      reply_to: "#{I18n.t('mailers.welcome.from', name: 'Tove')} <tove@goclimate.com>",
+      subject: I18n.t('mailers.business.newsletter_signup.subject'),
+      asm: { group_id: SENDGRID_ASM_GROUP_IDS[:business_newsletter] }
+    )
+  end
+end

--- a/app/models/newsletter_subscriber.rb
+++ b/app/models/newsletter_subscriber.rb
@@ -1,5 +1,33 @@
 # frozen_string_literal: true
 
 class NewsletterSubscriber < ApplicationRecord
+  belongs_to :user, optional: true
+
   validates :email, email: true, presence: true
+  validate :correct_newsletter_type
+  validate :user_id_exists
+  validates_uniqueness_of :email, scope: [:newsletter_type], message: 'duplicate'
+
+  scope :only_consumer, -> { where(newsletter_type: CONSUMER_TYPE) }
+  scope :only_business, -> { where(newsletter_type: BUSINESS_TYPE) }
+
+  CONSUMER_TYPE = 'consumer'
+  BUSINESS_TYPE = 'business'
+  NEWSLETTER_TYPES = [CONSUMER_TYPE, BUSINESS_TYPE].freeze
+
+  private
+
+  def correct_newsletter_type
+    self.newsletter_type = 'consumer' if newsletter_type.blank?
+
+    return if NEWSLETTER_TYPES.include?(newsletter_type)
+
+    errors.add(:newsletter_type, "must be one of #{NEWSLETTER_TYPES.join(', ')}")
+  end
+
+  def user_id_exists
+    return if user_id.blank?
+
+    errors.add(:user, 'must exist') unless User.exists?(user_id)
+  end
 end

--- a/app/views/business/advisory/show.html.erb
+++ b/app/views/business/advisory/show.html.erb
@@ -96,5 +96,7 @@
   </div>
 </section>
 
+<%= render 'business/shared/newsletter_subscription' %>
+
 <%= render 'shared/bottom_landscape' %>
-<%= render 'shared/footer', skip_prefooter: true %>
+<%= render 'shared/footer', skip_prefooter: true, skip_newsletter_signup: true %>

--- a/app/views/business/climate_report_invoices/thank_you.html.erb
+++ b/app/views/business/climate_report_invoices/thank_you.html.erb
@@ -9,8 +9,10 @@
   </div>
 </section>
 
-<%= render "shared/bottom_landscape" %>
-<%= render "shared/footer", skip_prefooter: true %>
+<%= render 'business/shared/newsletter_subscription' %>
+
+<%= render 'shared/bottom_landscape' %>
+<%= render 'shared/footer', skip_prefooter: true, skip_newsletter_signup: true %>
 
 <%= intercom_script_tag(
   custom_data: {

--- a/app/views/business/climate_reports/index.html.erb
+++ b/app/views/business/climate_reports/index.html.erb
@@ -55,5 +55,7 @@
   </div>
 </section>
 
+<%= render 'business/shared/newsletter_subscription' %>
+
 <%= render 'shared/bottom_landscape' %>
-<%= render 'shared/footer', skip_prefooter: true %>
+<%= render 'shared/footer', skip_prefooter: true, skip_newsletter_signup: true %>

--- a/app/views/business/climate_reports/new.html.erb
+++ b/app/views/business/climate_reports/new.html.erb
@@ -279,7 +279,9 @@
   </section>
 <% end %>
 
-<%= render "shared/bottom_landscape" %>
-<%= render "shared/footer", skip_prefooter: true %>
+<%= render 'business/shared/newsletter_subscription' %>
+
+<%= render 'shared/bottom_landscape' %>
+<%= render 'shared/footer', skip_prefooter: true, skip_newsletter_signup: true %>
 
 <%= intercom_script_tag %>

--- a/app/views/business/climate_reports/show.html.erb
+++ b/app/views/business/climate_reports/show.html.erb
@@ -244,8 +244,10 @@
   </p>
 </section>
 
-<%= render "shared/bottom_landscape" %>
-<%= render "shared/footer", skip_prefooter: true %>
+<%= render 'business/shared/newsletter_subscription' %>
+
+<%= render 'shared/bottom_landscape' %>
+<%= render 'shared/footer', skip_prefooter: true, skip_newsletter_signup: true %>
 
 <%= intercom_script_tag(
   custom_data: {

--- a/app/views/business/contacts/create.html.erb
+++ b/app/views/business/contacts/create.html.erb
@@ -9,5 +9,7 @@
   </div>
 </section>
 
-<%= render "shared/bottom_landscape" %>
-<%= render "shared/footer", skip_prefooter: true %>
+<%= render 'business/shared/newsletter_subscription' %>
+
+<%= render 'shared/bottom_landscape' %>
+<%= render 'shared/footer', skip_prefooter: true, skip_newsletter_signup: true %>

--- a/app/views/business/home/show.html.erb
+++ b/app/views/business/home/show.html.erb
@@ -72,8 +72,6 @@
       <%= link_to t('views.business.home.advisory.read_more'), business_advisory_path, class: 'button' %>
       </div>
     </div>
-    <div class="t:w-1/2 d:w-1/3">
-    </div>
   </div>
 </section>
 
@@ -87,8 +85,6 @@
         <%= link_to t('views.business.home.self_serve.read_more'), business_climate_reports_path, class: 'button' %>
       </div>
     </div>
-    <div class="t:w-1/2 d:w-1/3">
-    </div>
   </div>
 </section>
 
@@ -101,8 +97,6 @@
         <%= link_to I18n.t('views.business.home.offsetting.learn_more'), business_offsetting_path, class: 'button' %>
       </div>
     </div>
-    <div class="t:w-1/2 d:w-1/3">
-    </div>
   </div>
 </section>
 
@@ -112,18 +106,18 @@
       <h2 class="heading-lg"><%= t 'views.business.home.other_services.heading' %></h2>
       <p><%=t('views.business.home.other_services.text_html').gsub('<a', '<a class="link"').html_safe %></p>
     </div>
-    <div class="t:w-1/2 d:w-1/3">
-    </div>
   </div>
 </section>
 
-<section class="section-padding t:text-center space-y-6">
+<section class="section-padding space-y-6">
   <h2 class="heading-lg"><%=t 'views.business.home.questions.heading' %></h2>
-  <p class="t:w-2/3 d:w-1/2 mx-auto"><%=t('views.business.home.questions.text_html').gsub('<a', '<a class="link"').html_safe %></p>
-  <div class="flex justify-center">
+  <p class="t:w-2/3 d:w-1/2"><%=t('views.business.home.questions.text_html').gsub('<a', '<a class="link"').html_safe %></p>
+  <div class="flex">
     <%= link_to I18n.t('views.business.home.questions.cta'), faq_path(anchor: 'for_businesses-q1'), class: 'button' %>
   </div>
 </section>
 
+<%= render 'business/shared/newsletter_subscription' %>
+
 <%= render 'shared/bottom_landscape' %>
-<%= render 'shared/footer', skip_prefooter: true %>
+<%= render 'shared/footer', skip_prefooter: true, skip_newsletter_signup: true %>

--- a/app/views/business/offsetting/show.html.erb
+++ b/app/views/business/offsetting/show.html.erb
@@ -88,10 +88,12 @@
   </div>
 </section>
 
-<section class="section-padding t:text-center">
+<section class="section-padding">
   <h2 class="heading-lg"><%=t 'views.business.offsetting.other_ways.heading' %></h2>
-  <p class="mt-6 t:w-2/3 d:w-1/2 mx-auto"><%=t('views.business.offsetting.other_ways.text_html').gsub('<a', '<a class="link"').html_safe %></p>
+  <p class="mt-6 t:w-2/3 d:w-1/2"><%=t('views.business.offsetting.other_ways.text_html').gsub('<a', '<a class="link"').html_safe %></p>
 </section>
 
+<%= render 'business/shared/newsletter_subscription' %>
+
 <%= render 'shared/bottom_landscape' %>
-<%= render 'shared/footer', skip_prefooter: true %>
+<%= render 'shared/footer', skip_prefooter: true, skip_newsletter_signup: true %>

--- a/app/views/business/shared/_newsletter_subscription.html.erb
+++ b/app/views/business/shared/_newsletter_subscription.html.erb
@@ -1,0 +1,58 @@
+<section class="section-padding relative d:pt-24 text-center">
+  <div class="relative">
+    <div class="relative z-10 space-y-6">
+      <h2 class="heading-lg"><%= t 'views.business.shared.newsletter_signup.heading' %></h2>
+      <p><%= t 'views.business.shared.newsletter_signup.text' %></p>
+      <div>
+        <%= form_with url: NewsletterSubscriber.new(), html: { id: 'newsletter-subscription-form', class: 'relative', 'data-controller': 'newsletter-subscription' } do |f| %>
+          <%= f.hidden_field :user_id, value: current_user&.id || nil %>
+          <%= f.hidden_field :newsletter_type, value: NewsletterSubscriber::BUSINESS_TYPE %>
+          <%= f.hidden_field :region, value: ISO3166::Country.new(request.headers['CF-IPCountry'])&.alpha2 || current_region.country_codes || nil %>
+          <div class="flex flex-row justify-center space-x-2"
+            data-target="newsletter-subscription.formWrapper"
+            data-active-class="flex flex-row justify-center space-x-2"
+            data-inactive-class="invisible flex flex-row justify-center space-x-2">
+            <div class="relative">
+              <%= f.email_field :newsletter_email,
+                class: 'input',
+                placeholder: t('email'),
+                'data-target': 'newsletter-subscription.emailField',
+                'data-inactive-class': 'invisible'
+              %>
+              <p class="absolute mt-1" data-target="newsletter-subscription.errorMessage"></p>
+            </div>
+            <button
+              type="submit"
+              class="button button-cta relative"
+              data-action="click->newsletter-subscription#submit"
+            >
+              <span
+                data-target="newsletter-subscription.idleIndicator"
+                data-active-class="inline"
+                data-inactive-class="invisible"
+              ><%= t 'views.business.shared.newsletter_signup.cta' %></span>
+              <span
+                data-target="newsletter-subscription.loadingIndicator"
+                class="hidden"
+                data-active-class="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2"
+                data-inactive-class="hidden"
+              ><i class="fas fa-circle-notch fa-spin"></i></span>
+              <span
+                data-target="newsletter-subscription.successIndicator"
+                class="hidden"
+                data-active-class="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2"
+                data-inactive-class="hidden"
+              ><i class="fas fa-check"></i></span>
+            </button>
+          </div>
+          <p class="absolute top-1/2 w-full text-center font-bold transform -translate-y-1/2 hidden"
+            data-target="newsletter-subscription.successMessage"
+            data-active-class="absolute top-1/2 w-full text-center font-bold transform -translate-y-1/2"
+            data-inactive-class="hidden"
+          >Thank you!</p>
+        <% end %>
+      </div>
+    </div>
+    <%= image_tag webpack_asset_path('images/shapes/blob_3.svg'), class: 'w-full d:w-1/3 max-w-xs d:max-w-sm absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-0', alt: '' %>
+  </div>
+</section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -93,7 +93,7 @@
     </div>
 
     <% unless cookies[:cookie_consent].present? %>
-      <div id="cookie-consent-banner" class="fixed bottom-0 left-0 right-0 flex justify-between items-center p-4 t:px-8 bg-black text-white">
+      <div id="cookie-consent-banner" class="fixed bottom-0 left-0 right-0 flex justify-between items-center p-4 t:px-8 bg-black text-white z-50">
         <div class="flex items-end m-lg:items-center space-x-2 t:space-x-4">
           <p><%=t 'views.shared.cookie_banner.text' %> <%= link_to t('views.shared.cookie_banner.link_text'),  cookies_path, class: 'link text-white hover:text-white' %>.</p>
           <button id="cookie-consent-banner-consent" class="button button-sm button-inverted">

--- a/app/views/newsletter_mailer/business_newsletter_signup_email.html.erb
+++ b/app/views/newsletter_mailer/business_newsletter_signup_email.html.erb
@@ -1,0 +1,11 @@
+<%= render 'shared/email/heading',
+  text: t('mailers.business.newsletter_signup.subject') %>
+
+<%= render 'shared/email/spacer' %>
+
+<%= render 'shared/email/paragraph',
+  text: t('mailers.business.newsletter_signup.text') %>
+
+<%= render 'shared/email/spacer' %>
+
+<%= render 'shared/email/team_signature' %>

--- a/app/views/newsletter_mailer/business_newsletter_signup_email.text.erb
+++ b/app/views/newsletter_mailer/business_newsletter_signup_email.text.erb
@@ -1,0 +1,6 @@
+<%= t 'mailers.business.newsletter_signup.subject' %>
+
+<%= t 'mailers.business.newsletter_signup.text' %>
+
+<%= t 'best_regards' %>,
+GoClimate

--- a/app/views/newsletter_mailer/newsletter_signup_email.html.erb
+++ b/app/views/newsletter_mailer/newsletter_signup_email.html.erb
@@ -1,0 +1,11 @@
+<%= render 'shared/email/heading',
+  text: t('mailers.newsletter.sign_up.subject') %>
+
+<%= render 'shared/email/spacer' %>
+
+<%= render 'shared/email/paragraph',
+  text: t('mailers.newsletter.sign_up.text') %>
+
+<%= render 'shared/email/spacer' %>
+
+<%= render 'shared/email/team_signature' %>

--- a/app/views/newsletter_mailer/newsletter_signup_email.text.erb
+++ b/app/views/newsletter_mailer/newsletter_signup_email.text.erb
@@ -1,0 +1,6 @@
+<%= t('mailers.newsletter.sign_up.subject') %>
+
+<%= t('mailers.newsletter.sign_up.text') %>
+
+<%= t 'best_regards' %>,
+GoClimate

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -31,35 +31,50 @@
           </li>
         </ul>
 
-        <div>
-          <%= form_with url: NewsletterSubscriber.new(), html: { 'data-controller': 'newsletter-subscription' } do |f| %>
-            <%= f.hidden_field :logged_in_user_id, value: current_user&.id || nil %>
-            <%= f.label :newsletter_email, t('views.shared.footer.newsletter.heading'), class: 'font-bold' %>
-            <div class="flex flex-row space-x-2">
-              <%= f.email_field :newsletter_email, class: 'input input-sm', placeholder: t('email'), 'data-target': 'newsletter-subscription.emailField' %>
-              <button type="button" class="button button-inverted button-sm relative" data-action="click->newsletter-subscription#submit">
-                <span
-                  data-target="newsletter-subscription.idleIndicator"
-                  data-active-class="inline"
-                  data-inactive-class="invisible"
-                ><%= t('views.shared.footer.newsletter.cta') %></span>
-                <span
-                  data-target="newsletter-subscription.loadingIndicator"
-                  class="hidden"
-                  data-active-class="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2"
+        <% unless local_assigns[:skip_newsletter_signup] %>
+          <div>
+            <%= form_with url: NewsletterSubscriber.new(), html: { id: 'newsletter-subscription-form', 'data-controller': 'newsletter-subscription' } do |f| %>
+              <%= f.hidden_field :user_id, value: current_user&.id || nil %>
+              <%= f.hidden_field :newsletter_type, value: NewsletterSubscriber::CONSUMER_TYPE %>
+              <%= f.hidden_field :region, value: ISO3166::Country.new(request.headers['CF-IPCountry'])&.alpha2 || current_region.country_codes || nil %>
+              <%= f.label :newsletter_email, t('views.shared.footer.newsletter.heading'), class: 'font-bold' %>
+              <div class="relative">
+                <div class="flex flex-row space-x-2"
+                  data-target="newsletter-subscription.formWrapper"
+                  data-active-class="flex flex-row space-x-2"
+                  data-inactive-class="invisible flex flex-row space-x-2"
+                >
+                  <%= f.email_field :newsletter_email, class: 'input input-sm', placeholder: t('email'), 'data-target': 'newsletter-subscription.emailField' %>
+                  <button type="submit" id="newsletter-subscription-submit" class="button button-inverted button-sm relative" data-action="click->newsletter-subscription#submit">
+                    <span
+                      data-target="newsletter-subscription.idleIndicator"
+                      data-active-class="inline"
+                      data-inactive-class="invisible"
+                    ><%= t('views.shared.footer.newsletter.cta') %></span>
+                    <span
+                      data-target="newsletter-subscription.loadingIndicator"
+                      class="hidden"
+                      data-active-class="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2"
+                      data-inactive-class="hidden"
+                    ><i class="fas fa-circle-notch fa-spin"></i></span>
+                    <span
+                      data-target="newsletter-subscription.successIndicator"
+                      class="hidden"
+                      data-active-class="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2"
+                      data-inactive-class="hidden"
+                    ><i class="fas fa-check"></i></span>
+                  </button>
+                </div>
+                <p class="absolute" data-target="newsletter-subscription.errorMessage"></p>
+                <p class="absolute top-0 hidden"
+                  data-target="newsletter-subscription.successMessage"
+                  data-active-class="absolute top-0"
                   data-inactive-class="hidden"
-                ><i class="fas fa-circle-notch fa-spin"></i></span>
-                <span
-                  data-target="newsletter-subscription.successIndicator"
-                  class="hidden"
-                  data-active-class="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2"
-                  data-inactive-class="hidden"
-                ><i class="fas fa-check"></i></span>
-              </button>
-            </div>
-            <p data-target="newsletter-subscription.errorMessage"></p>
-          <% end %>
-        </div>
+                >Thank you!</p>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
       </div>
       <div class="w-full t:w-1/4 d:w-1/6 d:max-w-xs p-4">
         <h3 class="font-bold"><%= t('views.shared.footer.headers.make_a_difference') %></h3>

--- a/config/initializers/sendgrid_asm_group_ids.rb
+++ b/config/initializers/sendgrid_asm_group_ids.rb
@@ -9,7 +9,9 @@ SENDGRID_ASM_GROUP_IDS =
       invoice_certificates: 26_003,
       welcome: 27_414,
       payment_failed: 28_840,
-      data_requests: 29_667
+      data_requests: 29_667,
+      business_newsletter: 30_878,
+      newsletter: 18_797
     }
   else
     {
@@ -19,6 +21,8 @@ SENDGRID_ASM_GROUP_IDS =
       invoice_certificates: 12_404,
       welcome: 13_849,
       payment_failed: 15_417,
-      data_requests: 16_144
+      data_requests: 16_144,
+      business_newsletter: 16_871,
+      newsletter: 16_870
     }
   end

--- a/config/locales/views/business/shared.en.yml
+++ b/config/locales/views/business/shared.en.yml
@@ -1,0 +1,8 @@
+en:
+  views:
+    business:
+      shared:
+        newsletter_signup:
+          heading: Sign up to our business newsletter!
+          text: Receive tips and inspiration on how you as a company can improve your climate work 
+          cta: Subscribe

--- a/config/locales/views/business/shared.sv.yml
+++ b/config/locales/views/business/shared.sv.yml
@@ -1,0 +1,8 @@
+sv:
+  views:
+    business:
+      shared:
+        newsletter_signup:
+          heading: Prenumerera på vårt nyhetsbrev för företag!
+          text: Få tips och inspiration till hur ni som företag kan förbättra ert klimatarbete
+          cta: Prenumerera

--- a/config/locales/views/mailers/business.en.yml
+++ b/config/locales/views/mailers/business.en.yml
@@ -6,3 +6,6 @@ en:
         thank_you: Thank you for calculating your climate footprint!
         link_description: "To make it easier to share your results with your team and get back to them later, here's a link to the results:"
         reply_to_this_email: If you have any questions, just reply to this email. We're happy to help!
+      newsletter_signup:
+        subject: Thank you for signing up to our business newsletter
+        text: A couple of times each year, you will receive tips and inspiration on how you as a company can improve your climate work. We are excited to make this journey with you!

--- a/config/locales/views/mailers/business.sv.yml
+++ b/config/locales/views/mailers/business.sv.yml
@@ -6,3 +6,6 @@ sv:
         thank_you: Tack för att du gjort en klimatuträkning hos oss!
         link_description: "För att du enkelt ska kunna dela dina resultat med dina kollegor och hitta tillbaka till dem senare kommer här en länk till resultaten:"
         reply_to_this_email: Svara gärna på det här mailet om du har några frågor så hjälper vi mer än gärna till!
+      newsletter_signup:
+        subject: Tack för att du prenumererar på vårt nyhetsbrev för företag!
+        text: Några gånger per år kommer du att få tips och inspiration till hur ni som företag kan förbättra ert klimatarbete. Vi är jätteglada över att få göra denna resa med er!

--- a/config/locales/views/mailers/newsletter.en.yml
+++ b/config/locales/views/mailers/newsletter.en.yml
@@ -1,0 +1,6 @@
+en:
+  mailers:
+    newsletter:
+      sign_up:
+        subject: Thank you for signing up to our newsletter!
+        text: A couple of times each year, you will be updated on how GoClimate is doing, what projects we are financing and how we as a community are making an impact!

--- a/config/locales/views/mailers/newsletter.sv.yml
+++ b/config/locales/views/mailers/newsletter.sv.yml
@@ -1,0 +1,6 @@
+sv:
+  mailers:
+    newsletter:
+      sign_up:
+        subject: Tack för att du prenumererar på vårt nyhetsbrev!
+        text: Några gånger per år kommer vi uppdatera dig om hur det går för GoClimate, vilka projekt vi finansierar och hur vi som ett community gör gott för planeten!

--- a/db/migrate/20210916123617_remove_foreign_key_from_newsletter_subscribers.rb
+++ b/db/migrate/20210916123617_remove_foreign_key_from_newsletter_subscribers.rb
@@ -1,0 +1,5 @@
+class RemoveForeignKeyFromNewsletterSubscribers < ActiveRecord::Migration[6.0]
+  def change
+    remove_foreign_key :newsletter_subscribers, :users, column: :logged_in_user_id
+  end
+end

--- a/db/migrate/20210916123738_add_newsletter_type_to_newsletter_subscribers.rb
+++ b/db/migrate/20210916123738_add_newsletter_type_to_newsletter_subscribers.rb
@@ -1,0 +1,7 @@
+class AddNewsletterTypeToNewsletterSubscribers < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :newsletter_subscribers, :logged_in_user_id, :user_id
+
+    add_column :newsletter_subscribers, :newsletter_type, :text, default: 'consumer'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_08_095510) do
+ActiveRecord::Schema.define(version: 2021_09_16_123617) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -415,7 +416,6 @@ ActiveRecord::Schema.define(version: 2021_09_08_095510) do
   add_foreign_key "data_requests", "climate_reports_report_areas", column: "report_area_id"
   add_foreign_key "data_requests", "data_reporters", column: "recipient_id"
   add_foreign_key "invoices", "projects"
-  add_foreign_key "newsletter_subscribers", "users", column: "logged_in_user_id"
   add_foreign_key "price_increase_confirmations", "users"
   add_foreign_key "reported_data", "business_calculators_calculator_fields", column: "calculator_field_id"
   add_foreign_key "reported_data", "data_requests"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_16_123617) do
+ActiveRecord::Schema.define(version: 2021_09_16_123738) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -291,7 +291,8 @@ ActiveRecord::Schema.define(version: 2021_09_16_123617) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "email", null: false
     t.string "region"
-    t.bigint "logged_in_user_id"
+    t.bigint "user_id"
+    t.text "newsletter_type", default: "consumer"
   end
 
   create_table "organizations", force: :cascade do |t|

--- a/spec/factories/newsletter_subscriber.rb
+++ b/spec/factories/newsletter_subscriber.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :newsletter_subscriber do
-    # TODO: implement later
+    email { 'test@example.com' }
+    newsletter_type { 'consumer' }
   end
 end

--- a/spec/features/newsletter_subscription_spec.rb
+++ b/spec/features/newsletter_subscription_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Newsletter signup', type: :feature, js: true do
+  scenario 'Sign up to our newsletter in footer' do
+    visit '/'
+
+    fill_in 'newsletter_email', with: 'test@example.com'
+    find('#newsletter-subscription-form input').native.send_keys :enter
+
+    expect(page).to have_text('Thank you!', wait: 20)
+  end
+end

--- a/spec/mailers/previews/newsletter_mailer_preview.rb
+++ b/spec/mailers/previews/newsletter_mailer_preview.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/
+class NewsletterMailerPreview < ActionMailer::Preview
+  def newsletter_signup_email
+    NewsletterMailer.newsletter_signup_email('test@email.com')
+  end
+
+  def business_newsletter_signup_email
+    NewsletterMailer.business_newsletter_signup_email('test@email.com')
+  end
+end

--- a/spec/models/newsletter_subscriber_spec.rb
+++ b/spec/models/newsletter_subscriber_spec.rb
@@ -5,13 +5,53 @@ require 'rails_helper'
 RSpec.describe NewsletterSubscriber do
   describe '.new' do
     context 'with a valid email address' do
-      subject { build(:newsletter_subscriber, email: 'test@example.com') }
+      subject { build(:newsletter_subscriber) }
 
       it { is_expected.to be_valid }
     end
 
     context 'with an invalid email address' do
-      subject { build(:newsletter_subscriber, email: 'test.example.com') }
+      subject { build(:newsletter_subscriber, email: 'test@examplecom') }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context 'with a valid user id' do
+      subject { build(:newsletter_subscriber, user_id: user.id) }
+
+      let(:user) { create(:user) }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'with an invalid user id' do
+      subject { build(:newsletter_subscriber, user_id: 90_909_090) }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context 'with an invalid newsletter type' do
+      subject { build(:newsletter_subscriber, newsletter_type: 'invalid_type') }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context 'with an existing email but different newsletter type' do
+      subject(:newsletter_subscriber) { build(:newsletter_subscriber, newsletter_type: 'business') }
+
+      before do
+        create(:newsletter_subscriber, newsletter_type: 'consumer')
+      end
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'with a combination of email and newsletter type that already exists' do
+      subject(:newsletter_subscriber) { build(:newsletter_subscriber, newsletter_type: 'consumer') }
+
+      before do
+        create(:newsletter_subscriber, newsletter_type: 'consumer')
+      end
 
       it { is_expected.to be_invalid }
     end


### PR DESCRIPTION
## Business newsletter

- Added a sign up section in the bottom of each business page
- Removed the regular newsletter sign up from business pages
- The sign up only accepts valid and non-duplicated emails (duplicate emails are still shown as "accepted" to the user)
- When signing up, a confirmation email is sent to the address, see below for content.

<img width="1431" alt="Screenshot 2021-09-13 at 10 55 56" src="https://user-images.githubusercontent.com/8473077/133054741-9fba4320-b9ce-4488-a6a5-09a07eaba54f.png">


<img width="1433" alt="Screenshot 2021-09-13 at 10 56 41" src="https://user-images.githubusercontent.com/8473077/133054834-8d70f2f0-0472-4af7-8aa7-4f3bc78b94a1.png">


<img width="780" alt="Screenshot 2021-09-13 at 10 55 25" src="https://user-images.githubusercontent.com/8473077/133054781-744333a0-9eac-4e24-9d82-162829afd3cd.png">

---

## Regular newsletter

- Did some general refactoring of the code
- Added sign up confirmation email, see content below

<img width="746" alt="Screenshot 2021-09-13 at 10 55 39" src="https://user-images.githubusercontent.com/8473077/133054802-a5569b94-0262-4313-ab4f-4f67f323d106.png">